### PR TITLE
Fix movie api compilation errors

### DIFF
--- a/movieapi/src/main/java/dev/gihan/movieapi/controller/AdminController.java
+++ b/movieapi/src/main/java/dev/gihan/movieapi/controller/AdminController.java
@@ -4,6 +4,7 @@ import dev.gihan.movieapi.dto.requestDto.MovieRequestDto;
 import dev.gihan.movieapi.dto.responseDto.AdminStatsDto;
 import dev.gihan.movieapi.dto.responseDto.FileUploadResponseDto;
 import dev.gihan.movieapi.dto.responseDto.MessageResponseDto;
+import dev.gihan.movieapi.dto.responseDto.MovieResponseDto;
 import dev.gihan.movieapi.dto.responseDto.UserResponseDto;
 import dev.gihan.movieapi.model.Movie;
 import dev.gihan.movieapi.service.AdminService;
@@ -52,7 +53,7 @@ public class AdminController {
     @PostMapping("/movies")
     public ResponseEntity<?> createMovie(@RequestBody MovieRequestDto movieRequest) {
         try {
-            Movie movie = movieService.createMovie(movieRequest);
+            MovieResponseDto movie = movieService.createMovie(movieRequest);
             return ResponseEntity.status(HttpStatus.CREATED).body(movie);
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(new MessageResponseDto(e.getMessage()));
@@ -62,7 +63,7 @@ public class AdminController {
     @PutMapping("/movies/{id}")
     public ResponseEntity<?> updateMovie(@PathVariable Long id, @RequestBody MovieRequestDto movieRequest) {
         try {
-            Movie movie = movieService.updateMovie(id, movieRequest);
+            MovieResponseDto movie = movieService.updateMovie(id, movieRequest);
             return ResponseEntity.ok(movie);
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(new MessageResponseDto(e.getMessage()));

--- a/movieapi/src/main/java/dev/gihan/movieapi/controller/FavoriteController.java
+++ b/movieapi/src/main/java/dev/gihan/movieapi/controller/FavoriteController.java
@@ -54,7 +54,7 @@ public class FavoriteController {
                         .body("User not authenticated");
             }
 
-            Movie movie = movieService.getMovieById(movieId);
+            Movie movie = movieService.getMovieEntityById(movieId);
             favoriteService.addToFavorites(user, movie);
             return ResponseEntity.ok(new MessageResponseDto("Movie added to favorites"));
         } catch (Exception e) {
@@ -71,7 +71,7 @@ public class FavoriteController {
                         .body("User not authenticated");
             }
 
-            Movie movie = movieService.getMovieById(movieId);
+            Movie movie = movieService.getMovieEntityById(movieId);
             favoriteService.removeFromFavorites(user, movie);
             return ResponseEntity.ok(new MessageResponseDto("Movie removed from favorites"));
         } catch (Exception e) {

--- a/movieapi/src/main/java/dev/gihan/movieapi/controller/WatchLaterController.java
+++ b/movieapi/src/main/java/dev/gihan/movieapi/controller/WatchLaterController.java
@@ -54,7 +54,7 @@ public class WatchLaterController {
                         .body("User not authenticated");
             }
 
-            Movie movie = movieService.getMovieById(movieId);
+            Movie movie = movieService.getMovieEntityById(movieId);
             watchLaterService.addToWatchLater(user, movie);
             return ResponseEntity.ok(new MessageResponseDto("Movie added to watch later"));
         } catch (Exception e) {
@@ -71,7 +71,7 @@ public class WatchLaterController {
                         .body("User not authenticated");
             }
 
-            Movie movie = movieService.getMovieById(movieId);
+            Movie movie = movieService.getMovieEntityById(movieId);
             watchLaterService.removeFromWatchLater(user, movie);
             return ResponseEntity.ok(new MessageResponseDto("Movie removed from watch later"));
         } catch (Exception e) {

--- a/movieapi/src/main/java/dev/gihan/movieapi/exception/GlobalExceptionHandler.java
+++ b/movieapi/src/main/java/dev/gihan/movieapi/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package dev.gihan.movieapi.exception;
 
+import dev.gihan.movieapi.dto.responseDto.ErrorResponse;
 import dev.gihan.movieapi.dto.responseDto.MessageResponseDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
Fixes compilation errors by correcting type mismatches in controllers and adding missing imports.

The `AdminController` now correctly handles `MovieResponseDto` objects returned by the `MovieService` for API responses, maintaining the DTO pattern. Conversely, `FavoriteController` and `WatchLaterController` now use `getMovieEntityById` to retrieve `Movie` entities, which are required for their internal persistence operations, resolving previous type conflicts. Missing imports for `MovieResponseDto` and `ErrorResponse` were also added.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d20dd3c-ab11-4e8b-b6eb-2e28370b6446">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1d20dd3c-ab11-4e8b-b6eb-2e28370b6446">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>