### PR TITLE
Allow QuickTime video uploads

### DIFF
--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -165,7 +165,7 @@ export const TOAST_MESSAGES = {
 export const FILE_CONSTRAINTS = {
   VIDEO: {
     MAX_SIZE: 100 * 1024 * 1024, // 100MB
-    ALLOWED_TYPES: ['video/mp4', 'video/avi', 'video/mov', 'video/wmv', 'video/flv', 'video/webm'],
+    ALLOWED_TYPES: ['video/mp4', 'video/avi', 'video/quicktime', 'video/wmv', 'video/flv', 'video/webm'],
   },
   IMAGE: {
     MAX_SIZE: 5 * 1024 * 1024, // 5MB

--- a/movieapi/src/main/java/dev/gihan/movieapi/service/impl/FileUploadServiceImpl.java
+++ b/movieapi/src/main/java/dev/gihan/movieapi/service/impl/FileUploadServiceImpl.java
@@ -26,7 +26,7 @@ public class FileUploadServiceImpl implements FileUploadService {
     private String maxFileSize;
 
     private static final List<String> ALLOWED_VIDEO_TYPES = Arrays.asList(
-            "video/mp4", "video/avi", "video/mov", "video/wmv", "video/flv", "video/webm"
+            "video/mp4", "video/avi", "video/quicktime", "video/wmv", "video/flv", "video/webm"
     );
 
     private static final List<String> ALLOWED_IMAGE_TYPES = Arrays.asList(

--- a/movieapi/src/test/java/dev/gihan/movieapi/service/impl/FileUploadServiceImplTest.java
+++ b/movieapi/src/test/java/dev/gihan/movieapi/service/impl/FileUploadServiceImplTest.java
@@ -1,0 +1,25 @@
+package dev.gihan.movieapi.service.impl;
+
+import dev.gihan.movieapi.service.FileUploadService;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FileUploadServiceImplTest {
+
+    private final FileUploadService fileUploadService = new FileUploadServiceImpl();
+
+    @Test
+    void acceptsQuicktimeVideo() {
+        MockMultipartFile file = new MockMultipartFile("file", "sample.mov", "video/quicktime", new byte[10]);
+        assertTrue(fileUploadService.isValidVideoFile(file));
+    }
+
+    @Test
+    void rejectsUnsupportedVideoType() {
+        MockMultipartFile file = new MockMultipartFile("file", "sample.xyz", "video/xyz", new byte[10]);
+        assertFalse(fileUploadService.isValidVideoFile(file));
+    }
+}
+


### PR DESCRIPTION
## Summary
- accept QuickTime videos by correcting MOV mime type
- keep frontend upload constraints in sync
- test file validation for QuickTime videos

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `mvn -q -o test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6891076a1b44832b895a7c82eed7e86b