### PR TITLE
Remove unused manifest link from React index

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -10,11 +10,7 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
## Summary
- remove manifest link from frontend index template to avoid referencing missing file

## Testing
- `CI=true npm test -- --passWithNoTests`
- `mvn -q test` *(fails: Non-resolvable parent POM due to unreachable Maven repository)*

------
https://chatgpt.com/codex/tasks/task_e_6895ffa49508832ba7b7e9a391a4133a