### PR TITLE
Use API endpoint constant for movie ping

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -5,7 +5,7 @@ import { useMovies } from '../hooks/useMovies';
 import { useAuth } from '../hooks/useAuth';
 import MovieGrid from '../components/movie/MovieGrid';
 import { SkeletonLoader } from '../components/common/Loader';
-import { API_BASE_URL } from '../utils/constants';
+import { API_BASE_URL, API_ENDPOINTS } from '../utils/constants';
 
 const Home = () => {
   const { isAuthenticated } = useAuth();
@@ -24,7 +24,7 @@ const Home = () => {
     // Test API connection
     const testApiConnection = async () => {
       try {
-        const response = await fetch(`${API_BASE_URL}/movies`);
+        const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.MOVIES.BASE}`);
         if (response.ok) {
           setApiStatus('connected');
         } else {


### PR DESCRIPTION
## Summary
- use API_ENDPOINTS.MOVIES.BASE for Home page API ping

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*
- `curl -i http://localhost:8081/api/movies`

------
https://chatgpt.com/codex/tasks/task_e_6895ffa3cf3c832baa4f34c007d0bc8d