### PR TITLE
Align API base URL with backend port 8080

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,2 @@
+REACT_APP_API_URL=http://localhost:8080
+

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -1,5 +1,5 @@
 // API Base URL
-export const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8081';
+export const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8080';
 
 // API Endpoints
 export const API_ENDPOINTS = {

--- a/movieapi/src/main/resources/application.properties
+++ b/movieapi/src/main/resources/application.properties
@@ -15,7 +15,7 @@ spring.mvc.contentnegotiation.parameter-name=mediaType
 
 # Database Configuration - Use environment variables for security
 spring.application.name=movieapi
-server.port=${SERVER_PORT:8081}
+server.port=${SERVER_PORT:8080}
 spring.datasource.url=${DB_URL:jdbc:mysql://localhost:3306/moviedb?createDatabaseIfNotExist=true}
 spring.datasource.username=${DB_USERNAME:movieuser}
 spring.datasource.password=${DB_PASSWORD:moviepass}


### PR DESCRIPTION
## Summary
- default API base URL points to `http://localhost:8080`
- backend `server.port` now defaults to 8080 to match frontend
- added `.env` file setting `REACT_APP_API_URL`

## Testing
- `npm test --prefix frontend -- --watchAll=false --passWithNoTests`
- `mvn -q test` *(fails: Network is unreachable for Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6895ffa15bac832b86391db22885af28